### PR TITLE
Use Save As dialog for file export instead of direct download

### DIFF
--- a/Layout/Header.razor
+++ b/Layout/Header.razor
@@ -80,8 +80,12 @@
             string fileName = $"reci-export-{DateTime.Now:yyyy-MM-dd-HHmmss}.reci";
             
             await JSRuntime.InvokeVoidAsync("downloadFile", fileName, jsonContent);
-            
+
             ToastService.ShowSuccess("Data exported successfully");
+        }
+        catch (JSException ex) when (ex.Message.Contains("AbortError"))
+        {
+            // User cancelled the save dialog
         }
         catch (Exception ex)
         {

--- a/wwwroot/js/fileHelper.js
+++ b/wwwroot/js/fileHelper.js
@@ -1,5 +1,26 @@
-window.downloadFile = function (filename, content) {
+window.downloadFile = async function (filename, content) {
     const blob = new Blob([content], { type: 'application/json' });
+
+    if (window.showSaveFilePicker) {
+        try {
+            const handle = await window.showSaveFilePicker({
+                suggestedName: filename,
+                types: [{
+                    description: 'Reci Files',
+                    accept: { 'application/json': ['.reci'] }
+                }]
+            });
+            const writable = await handle.createWritable();
+            await writable.write(blob);
+            await writable.close();
+            return;
+        } catch (err) {
+            if (err.name === 'AbortError') {
+                throw err;
+            }
+        }
+    }
+
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;


### PR DESCRIPTION
Use the File System Access API (showSaveFilePicker) to prompt users for a save location and filename when exporting, falling back to the default browser download for unsupported browsers.