### PR TITLE
Move styles to component CSS files

### DIFF
--- a/Components/IngredientsDisplay.razor.css
+++ b/Components/IngredientsDisplay.razor.css
@@ -1,0 +1,31 @@
+.ingredient-list {
+    list-style-position: outside;
+    padding-left: 1.5rem;
+    margin: 0;
+    list-style-type: disc;
+}
+
+.ingredient-item {
+    line-height: 1.6;
+    color: var(--neutral-foreground-rest);
+}
+
+.ingredient-item:not(:last-child) {
+    margin-bottom: 0.75rem;
+}
+
+.ingredient-item strong {
+    color: var(--accent-fill-rest);
+}
+
+@media (max-width: 768px) {
+    .ingredient-list {
+        padding-left: 1.25rem;
+    }
+}
+
+@media print {
+    .ingredient-item {
+        page-break-inside: avoid;
+    }
+}

--- a/Components/InstructionsDisplay.razor.css
+++ b/Components/InstructionsDisplay.razor.css
@@ -1,0 +1,30 @@
+.instruction-list {
+    list-style-position: outside;
+    padding-left: 1.5rem;
+    margin: 0;
+}
+
+.instruction-item {
+    line-height: 1.6;
+    color: var(--neutral-foreground-rest);
+}
+
+.instruction-item:not(:last-child) {
+    margin-bottom: 0.75rem;
+}
+
+.instruction-item::marker {
+    font-weight: var(--font-weight-semibold);
+}
+
+@media (max-width: 768px) {
+    .instruction-list {
+        padding-left: 1.25rem;
+    }
+}
+
+@media print {
+    .instruction-item {
+        page-break-inside: avoid;
+    }
+}

--- a/Components/RecipeEditor/RecipeEditor.razor
+++ b/Components/RecipeEditor/RecipeEditor.razor
@@ -21,8 +21,8 @@
                 </FluentTextField>
              </FluentGridItem>
             <FluentGridItem xs="12" sm="6" md="6" lg="6">
-                <div style="display: flex; gap: 8px;">
-                    <div style="flex: 1;">
+                <div class="group-selector">
+                    <div class="group-selector-input">
                         <FluentCombobox TOption="Group"
                                     @bind-Value="newGroupName"
                                     @bind-SelectedOption="Content.Group"

--- a/Components/RecipeEditor/RecipeEditor.razor.css
+++ b/Components/RecipeEditor/RecipeEditor.razor.css
@@ -1,0 +1,8 @@
+.group-selector {
+    display: flex;
+    gap: 8px;
+}
+
+.group-selector-input {
+    flex: 1;
+}

--- a/Layout/Header.razor
+++ b/Layout/Header.razor
@@ -3,15 +3,15 @@
 @inject IToastService ToastService
 @inject NavigationManager NavigationManager
 
-<div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-    <div style="display: flex; align-items: center; cursor: pointer;" @onclick="NavigateToHome">
-        <img src="icon-192-no-background.png" alt="Reci Unicorn" style="width: 40px; height: 40px;" />
+<div class="header-container">
+    <div class="header-brand" @onclick="NavigateToHome">
+        <img src="icon-192-no-background.png" alt="Reci Unicorn" class="header-logo" />
         <FluentLabel Typo="Typography.Header" Color="Color.Lightweight" Weight="FontWeight.Bold">
             Reci
         </FluentLabel>
     </div>
 
-    <div style="display: flex; gap: 8px; align-items: center;">
+    <div class="header-actions">
         @if (PendingChanges)
         {
             <FluentLabel>Unsaved changes</FluentLabel>

--- a/Layout/Header.razor.css
+++ b/Layout/Header.razor.css
@@ -1,1 +1,23 @@
-/* */
+.header-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+}
+
+.header-brand {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.header-logo {
+    width: 40px;
+    height: 40px;
+}
+
+.header-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}

--- a/Layout/MainLayout.razor.css
+++ b/Layout/MainLayout.razor.css
@@ -1,0 +1,5 @@
+.content {
+    padding: 1.5rem 1.5rem;
+    align-self: stretch !important;
+    width: 100%;
+}

--- a/Layout/NavMenu.razor.css
+++ b/Layout/NavMenu.razor.css
@@ -1,1 +1,52 @@
-/* */
+.navmenu-icon {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    nav.sitenav {
+        width: 100%;
+        height: 100%;
+    }
+
+    ::deep #main-menu {
+        width: 100% !important;
+    }
+
+    ::deep #main-menu > div:first-child:is(.expander) {
+        display: none;
+    }
+
+    .navmenu {
+        width: 100%;
+    }
+
+    #navmenu-toggle {
+        appearance: none;
+    }
+
+    #navmenu-toggle ~ nav {
+        display: none;
+    }
+
+    #navmenu-toggle:checked ~ nav {
+        display: block;
+    }
+
+    .navmenu-icon {
+        cursor: pointer;
+        z-index: 10;
+        display: block;
+        position: absolute;
+        top: 15px;
+        left: unset;
+        right: 20px;
+        width: 20px;
+        height: 20px;
+        border: none;
+    }
+
+    [dir="rtl"] .navmenu-icon {
+        left: 20px;
+        right: unset;
+    }
+}

--- a/Pages/Contents.razor
+++ b/Pages/Contents.razor
@@ -28,7 +28,8 @@ else if (filteredGroups is null || !filteredGroups.Any())
     </FluentStack>
 }
 else
-{            
+{
+    <div>
     <FluentGrid Spacing="2" Justify="JustifyContent.FlexStart">
         @foreach (GroupVM<RecipeSummaryVM> group in filteredGroups.OrderBy(g => g.SortOrder))
         {
@@ -69,6 +70,7 @@ else
             <FluentGridItem xs="12" Style="margin-bottom: 10px;"></FluentGridItem>
         }
     </FluentGrid>
+    </div>
 }
 
 @code {

--- a/Pages/Contents.razor.css
+++ b/Pages/Contents.razor.css
@@ -1,0 +1,19 @@
+::deep .recipe-card {
+    cursor: pointer;
+    height: 100%;
+    background: var(--neutral-fill-stealth-rest) !important;
+}
+
+::deep .recipe-card:hover {
+    background: var(--neutral-fill-secondary-rest) !important;
+}
+
+::deep .recipe-description {
+    color: var(--neutral-foreground-hint);
+    font-size: 0.875rem;
+    margin: 0.5rem 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -8,10 +8,6 @@ body {
     margin: 0;
 }
 
-.navmenu-icon {
-    display: none;
-}
-
 .main {
     min-height: calc(100dvh - 86px);
     color: var(--neutral-foreground-rest);
@@ -22,12 +18,6 @@ body {
     align-self: stretch;
     height: calc(100dvh - 86px) !important;
     display: flex;
-}
-
-.content {
-    padding: 1.5rem 1.5rem;
-    align-self: stretch !important;
-    width: 100%;
 }
 
 footer {
@@ -50,12 +40,6 @@ footer {
         footer a:hover {
             text-decoration: underline;
         }
-
-.alert {
-    border: 1px dashed var(--accent-fill-rest);
-    padding: 5px;
-}
-
 
 #blazor-error-ui {
     background: lightyellow;
@@ -236,53 +220,6 @@ code {
         flex-direction: column !important;
         row-gap: 0 !important;
     }
-
-    nav.sitenav {
-        width: 100%;
-        height: 100%;
-    }
-
-    #main-menu {
-        width: 100% !important;
-    }
-
-        #main-menu > div:first-child:is(.expander) {
-            display: none;
-        }
-
-    .navmenu {
-        width: 100%;
-    }
-
-    #navmenu-toggle {
-        appearance: none;
-    }
-
-        #navmenu-toggle ~ nav {
-            display: none;
-        }
-
-        #navmenu-toggle:checked ~ nav {
-            display: block;
-        }
-
-    .navmenu-icon {
-        cursor: pointer;
-        z-index: 10;
-        display: block;
-        position: absolute;
-        top: 15px;
-        left: unset;
-        right: 20px;
-        width: 20px;
-        height: 20px;
-        border: none;
-    }
-
-    [dir="rtl"] .navmenu-icon {
-        left: 20px;
-        right: unset;
-    }
 }
 
 :root {
@@ -295,73 +232,7 @@ code {
     }
 }
 
-.recipe-card {
-    cursor: pointer;
-    height: 100%;
-    background: var(--neutral-fill-stealth-rest) !important;
-}
-
-    .recipe-card:hover {
-        background: var(--neutral-fill-secondary-rest) !important;
-    }
-
-.recipe-description {
-    color: var(--neutral-foreground-hint);
-    font-size: 0.875rem;
-    margin: 0.5rem 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
-.ingredient-list,
-.instruction-list {
-    list-style-position: outside;
-    padding-left: 1.5rem;
-    margin: 0;
-}
-
-.ingredient-list {
-    list-style-type: disc;
-}
-
-.ingredient-item,
-.instruction-item {
-    line-height: 1.6;
-    color: var(--neutral-foreground-rest);
-}
-
-    .ingredient-item:not(:last-child),
-    .instruction-item:not(:last-child) {
-        margin-bottom: 0.75rem;
-    }
-
-.instruction-item::marker {
-    font-weight: var(--font-weight-semibold);
-}
-
-.ingredient-item strong {
-    color: var(--accent-fill-rest);
-}
-
 .fluent-card-minimal-style {
     border: none !important;
     box-shadow: none !important;
-}
-
-/* Mobile Responsive Styles */
-@media (max-width: 768px) {
-    .ingredient-list,
-    .instruction-list {
-        padding-left: 1.25rem;
-    }
-}
-
-/* Print Styles */
-@media print {
-    .ingredient-item,
-    .instruction-item {
-        page-break-inside: avoid;
-    }
 }


### PR DESCRIPTION
Split and scope global styles into component-specific CSS files and update markup to use class names. Added CSS for IngredientsDisplay, InstructionsDisplay, RecipeEditor, MainLayout, and Contents; moved header/nav responsive rules into Layout/Header.razor.css and Layout/NavMenu.razor.css. Updated Header.razor and RecipeEditor.razor to use class-based layout (header-brand, header-actions, header-logo, group-selector, group-selector-input) and wrapped the grid in Pages/Contents.razor with a container div. Removed the related global rules from wwwroot/css/app.css to reduce global leakage and improve maintainability and responsiveness.

closes #14 