### PR TITLE
Add validation to Recipe editor and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Reci is a privacy-first, client-side recipe manager built with **Blazor WebAssembly (.NET 10)** and **Microsoft Fluent UI**. There is no backend server — all data is stored locally on the user's device via the File System Access API. Each recipe is an individual `.reci` JSON file organized in subdirectories by group.
+
+## Commands
+
+```bash
+# Dev server (http://localhost:5265)
+dotnet run
+
+# Build
+dotnet build -c Release
+
+# Format check (enforced by CI on push/PR to dev)
+dotnet format Reci.slnx --verify-no-changes
+
+# Auto-fix formatting
+dotnet format Reci.slnx
+
+# Run E2E tests (AppFixture starts the app automatically)
+dotnet test --project Tests/Tests.csproj
+
+# Update golden screenshots after intentional UI changes
+UPDATE_SNAPSHOTS=true dotnet test --project Tests/Tests.csproj
+
+# One-time Playwright browser install
+dotnet build Tests/Tests.csproj && pwsh Tests/bin/Debug/net10.0/playwright.ps1 install
+```
+
+## Architecture
+
+**Layered structure:**
+- `Pages/` — Routable pages (`Contents.razor` at `/`, `RecipePage.razor` at `/recipe/{slug}`)
+- `Layout/` — App shell (`MainLayout`, `NavMenu`, `Header`)
+- `Components/` — Reusable Razor components split into `RecipeDisplay/` and `RecipeEditor/`
+- `Services/` — Business logic, all registered as **Scoped** in `Program.cs`, coded to interfaces in `Services/Interfaces/`
+- `Data/Repositories/` — `FileSystemRecipeRepository` with in-memory cache + semaphore locking
+- `Data/Models/` — Record types (`Recipe`, `Ingredient`, `Instruction`, etc.)
+- `Core/` — Utilities (`Result<T>` railway-oriented error handling, `FileNameHelper`, extension methods)
+
+**Key patterns:**
+- Cross-component state sync via `IRecipeStateNotifier` (pub-sub); components implement `IAsyncDisposable` to unsubscribe
+- Error handling uses `Result<T>` — prefer `Result.Success()`/`Result.Failure()` over exceptions for expected failures
+- JS interop through `wwwroot/js/fileSystemHelper.js` bridged via `FileSystemAccessService`
+- File names: `{SanitizedName}_{8-char GUID}.reci` (see `FileNameHelper`)
+- JSON serialization: camelCase, indented, null values omitted
+
+## Code Style
+
+- C# nullable reference types and implicit usings enabled
+- Models use **records** for immutability (`Ingredient`, `Instruction`, `RecipeSummary`); `Recipe` is a mutable class
+- PascalCase for C#, `_camelCase` for private fields, camelCase for JSON, kebab-case for CSS
+- Component-scoped CSS via `.razor.css` files; global styles in `wwwroot/css/app.css`
+- `IGroupable` interface for items supporting grouping (ingredients, instructions)
+- Async throughout with `CancellationToken` support
+- Prefer explicit types over `var` (enforced by .editorconfig at warning level)
+- UI uses Fluent UI components (`FluentButton`, `FluentDialog`, etc.)
+- Global usings declared in `Reci.csproj` `<Using>` items
+
+## Testing
+
+- **xunit.v3** + **Microsoft.Playwright** for E2E browser automation
+- `AppFixture` (shared via `AppCollection`) manages the app process lifecycle
+- `ReciPage` base class provides Playwright page helpers
+- `[ReciPageState]` attribute injects JSON state before tests
+- `ScreenshotAssert` does golden-image visual regression against `Tests/Resources/Golden Screenshots/`

--- a/Components/RecipeEditor/RecipeEditor.razor
+++ b/Components/RecipeEditor/RecipeEditor.razor
@@ -5,8 +5,8 @@
 @inject IToastService ToastService
 
 <FluentDialogBody>
-<EditForm Model="@Content" Context="editContext" style="overflow-x: hidden; padding-right: 12px;">
-        <FluentValidationSummary />
+<EditForm EditContext="@_editContext" Context="editContext" style="overflow-x: hidden; padding-inline: 2px; padding-right: 12px;">
+        <DataAnnotationsValidator />
 
         @* Basic Information Section *@
         <FluentGrid Spacing="1" Style="margin-bottom: 12px">
@@ -19,6 +19,7 @@
                         <FluentLabel Typo="Typography.Subject">Name</FluentLabel>
                     </LabelTemplate>
                 </FluentTextField>
+                <FluentValidationMessage For="@(() => Content.Name)" />
              </FluentGridItem>
             <FluentGridItem xs="12" sm="6" md="6" lg="6">
                 <div class="group-selector">
@@ -201,6 +202,7 @@
     </FluentButton>
 
     <FluentButton Appearance="Appearance.Accent"
+                  Disabled="@_hasValidationErrors"
                   OnClick="OnSaveClick">
         Save
     </FluentButton>
@@ -225,6 +227,11 @@
 
     private async Task OnSaveClick()
     {
+        if (_editContext?.Validate() != true)
+        {
+            return;
+        }
+
         Result saveResult = await RecipeService.SaveRecipeAsync(Content, _cts.Token);
 
         if (saveResult.IsSuccess)
@@ -292,6 +299,8 @@
 
     private string? newTag;
 
+    private EditContext? _editContext;
+    private bool _hasValidationErrors;
     private List<string> existingGroupNames = [];
     private CancellationTokenSource _cts = new();
 
@@ -359,6 +368,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        _editContext = new EditContext(Content);
+        _editContext.OnValidationStateChanged += OnValidationStateChanged;
         List<RecipeSummary> summaries = await RecipeService.GetRecipeSummariesAsync(_cts.Token);
         existingGroupNames = summaries
             .Where(s => !string.IsNullOrEmpty(s.Group))
@@ -370,9 +381,19 @@
 
     public ValueTask DisposeAsync()
     {
+        if (_editContext is not null)
+        {
+            _editContext.OnValidationStateChanged -= OnValidationStateChanged;
+        }
         _cts.Cancel();
         _cts.Dispose();
         return ValueTask.CompletedTask;
+    }
+
+    private void OnValidationStateChanged(object? sender, ValidationStateChangedEventArgs e)
+    {
+        _hasValidationErrors = _editContext?.GetValidationMessages().Any() == true;
+        StateHasChanged();
     }
 
     private void EnsureNutritionInfo()

--- a/Data/Models/Recipe.cs
+++ b/Data/Models/Recipe.cs
@@ -1,9 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Reci.Data.Models;
 
 public class Recipe
 {
     public Guid Id { get; set; }
 
+    [Required(ErrorMessage = "Recipe name is required.")]
     public required string Name { get; set; }
 
     public string? Description { get; set; }


### PR DESCRIPTION
Add CLAUDE.md with repository guidance for Claude Code. Update RecipeEditor.razor to use an EditContext and DataAnnotationsValidator, show validation messages for the Name field, track validation state to disable the Save button when there are errors, and validate before saving. Manage EditContext lifecycle (subscribe/unsubscribe OnValidationStateChanged) and adjust small layout padding. Add [Required] validation attribute to Recipe.Name with a custom error message.