### PR TITLE
Fix recipe cache corruption by deep cloning in editor

### DIFF
--- a/Components/RecipeEditor/RecipeEditor.razor
+++ b/Components/RecipeEditor/RecipeEditor.razor
@@ -368,6 +368,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        Content = Content.DeepClone();
         _editContext = new EditContext(Content);
         _editContext.OnValidationStateChanged += OnValidationStateChanged;
         List<RecipeSummary> summaries = await RecipeService.GetRecipeSummariesAsync(_cts.Token);

--- a/Data/Models/Recipe.cs
+++ b/Data/Models/Recipe.cs
@@ -48,6 +48,7 @@ public static class RecipeExtensions
 
     public static Recipe DeepClone(this Recipe recipe)
     {
+        ArgumentNullException.ThrowIfNull(recipe);
         return new Recipe
         {
             Id = recipe.Id,

--- a/Data/Models/Recipe.cs
+++ b/Data/Models/Recipe.cs
@@ -46,6 +46,23 @@ public static class RecipeExtensions
             && string.IsNullOrEmpty(recipe.FurtherNotes);
     }
 
+    public static Recipe DeepClone(this Recipe recipe)
+    {
+        return new Recipe
+        {
+            Id = recipe.Id,
+            Name = recipe.Name,
+            Description = recipe.Description,
+            Group = recipe.Group,
+            Ingredients = recipe.Ingredients.Select(i => i with { }).ToList(),
+            Instructions = recipe.Instructions.Select(i => i with { }).ToList(),
+            NutritionInfo = recipe.NutritionInfo is not null ? recipe.NutritionInfo with { } : null,
+            Source = recipe.Source is not null ? recipe.Source with { } : null,
+            Tags = [.. recipe.Tags],
+            FurtherNotes = recipe.FurtherNotes
+        };
+    }
+
     public static bool IsEqualTo(this Recipe? first, Recipe? second)
     {
         if (first is null && second is null)


### PR DESCRIPTION
The RecipeEditor was mutating the same Recipe object reference held in the repository cache. Cancelling an edit left the cache with partial changes. Clone the recipe on editor init so mutations only affect the copy.