### PR TITLE
Replace Guid ID with Name+Group composite key

### DIFF
--- a/Components/RecipeEditor/RecipeEditor.razor
+++ b/Components/RecipeEditor/RecipeEditor.razor
@@ -187,7 +187,7 @@
 </FluentDialogBody>
 
 <FluentDialogFooter>
-    @if (Content.Id != Guid.Empty)
+    @if (!Content.IsNew)
     {
         <FluentButton Appearance="Appearance.Accent"
                       OnClick="OnDeleteClick">
@@ -232,7 +232,7 @@
             return;
         }
 
-        Result saveResult = await RecipeService.SaveRecipeAsync(Content, _cts.Token);
+        Result saveResult = await RecipeService.SaveRecipeAsync(Content, _originalKey, _cts.Token);
 
         if (saveResult.IsSuccess)
         {
@@ -251,7 +251,7 @@
 
     private async Task OnCancelClick()
     {
-        bool isNewRecipe = Content.Id == Guid.Empty;
+        bool isNewRecipe = Content.IsNew;
 
         if (isNewRecipe)
         {
@@ -265,7 +265,7 @@
         }
         else
         {
-            bool recipeModified = await RecipeService.IsRecipeModifiedAsync(Content, _cts.Token);
+            bool recipeModified = await RecipeService.IsRecipeModifiedAsync(Content, _originalKey, _cts.Token);
 
             if (!recipeModified && Dialog is not null)
             {
@@ -290,7 +290,8 @@
 
         if (!result.Cancelled && Dialog is not null)
         {
-            await RecipeService.DeleteRecipeAsync(Content.Id, _cts.Token);
+            RecipeKey deleteKey = _originalKey ?? new RecipeKey(Content.Name, Content.Group);
+            await RecipeService.DeleteRecipeAsync(deleteKey, _cts.Token);
             await Dialog.CloseAsync();
         }
     }
@@ -298,6 +299,7 @@
     #endregion
 
     private string? newTag;
+    private RecipeKey? _originalKey;
 
     private EditContext? _editContext;
     private bool _hasValidationErrors;
@@ -368,6 +370,10 @@
 
     protected override async Task OnInitializedAsync()
     {
+        if (!Content.IsNew)
+        {
+            _originalKey = new RecipeKey(Content.Name, Content.Group);
+        }
         Content = Content.DeepClone();
         _editContext = new EditContext(Content);
         _editContext.OnValidationStateChanged += OnValidationStateChanged;

--- a/Core/FileNameHelper.cs
+++ b/Core/FileNameHelper.cs
@@ -3,28 +3,22 @@ namespace Reci.Core;
 public static partial class FileNameHelper
 {
     private const int MaxFileNameLength = 200;
-    private const int GuidPrefixLength = 8;
     private const string FileExtension = ".reci";
 
     [GeneratedRegex(@"[<>:""/\\|?*\x00-\x1F]")]
     private static partial Regex InvalidFileNameCharsRegex();
 
-    public static string ToFileName(string recipeName, Guid recipeId)
+    public static string ToFileName(string recipeName)
     {
         string sanitized = SanitizeForFileSystem(recipeName);
-        string guidPrefix = recipeId.ToString("N")[..GuidPrefixLength];
-
-        string baseName = $"{sanitized}_{guidPrefix}";
 
         int maxBaseLength = MaxFileNameLength - FileExtension.Length;
-        if (baseName.Length > maxBaseLength)
+        if (sanitized.Length > maxBaseLength)
         {
-            int maxSanitizedLength = maxBaseLength - GuidPrefixLength - 1;
-            sanitized = sanitized[..maxSanitizedLength].TrimEnd();
-            baseName = $"{sanitized}_{guidPrefix}";
+            sanitized = sanitized[..maxBaseLength].TrimEnd();
         }
 
-        return $"{baseName}{FileExtension}";
+        return $"{sanitized}{FileExtension}";
     }
 
     public static string SanitizeForFileSystem(string name)
@@ -44,49 +38,4 @@ public static partial class FileNameHelper
 
         return sanitized;
     }
-
-    public static ParsedFileName? ParseFileName(string fileName)
-    {
-        if (string.IsNullOrWhiteSpace(fileName))
-        {
-            return null;
-        }
-
-        if (!fileName.EndsWith(FileExtension, StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        string withoutExtension = fileName[..^FileExtension.Length];
-        int lastUnderscore = withoutExtension.LastIndexOf('_');
-
-        if (lastUnderscore < 0 || lastUnderscore == withoutExtension.Length - 1)
-        {
-            return new ParsedFileName(withoutExtension, null);
-        }
-
-        string namePart = withoutExtension[..lastUnderscore];
-        string guidPrefix = withoutExtension[(lastUnderscore + 1)..];
-
-        if (guidPrefix.Length == GuidPrefixLength)
-        {
-            return new ParsedFileName(namePart, guidPrefix);
-        }
-
-        return new ParsedFileName(withoutExtension, null);
-    }
-
-    public static string? FindFileByGuidPrefix(IEnumerable<string> fileNames, Guid recipeId)
-    {
-        string guidPrefix = recipeId.ToString("N")[..GuidPrefixLength];
-
-        return fileNames.FirstOrDefault(f =>
-        {
-            ParsedFileName? parsed = ParseFileName(f);
-            return parsed?.GuidPrefix != null
-                && parsed.GuidPrefix.Equals(guidPrefix, StringComparison.OrdinalIgnoreCase);
-        });
-    }
 }
-
-public record ParsedFileName(string Name, string? GuidPrefix);

--- a/Core/RecipeKey.cs
+++ b/Core/RecipeKey.cs
@@ -1,0 +1,49 @@
+namespace Reci.Core;
+
+public readonly record struct RecipeKey(string Name, string? Group) : IEquatable<RecipeKey>
+{
+    public bool Equals(RecipeKey other)
+    {
+        return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Group, other.Group, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(
+            StringComparer.OrdinalIgnoreCase.GetHashCode(Name),
+            Group is not null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Group) : 0);
+    }
+
+    public string ToSlug()
+    {
+        string encodedName = Uri.EscapeDataString(Name);
+
+        if (string.IsNullOrEmpty(Group))
+        {
+            return encodedName;
+        }
+
+        string encodedGroup = Uri.EscapeDataString(Group);
+        return $"{encodedGroup}/{encodedName}";
+    }
+
+    public static RecipeKey FromSlug(string slug)
+    {
+        if (string.IsNullOrEmpty(slug))
+        {
+            return default;
+        }
+
+        int separatorIndex = slug.IndexOf('/');
+
+        if (separatorIndex < 0)
+        {
+            return new RecipeKey(Uri.UnescapeDataString(slug), null);
+        }
+
+        string group = Uri.UnescapeDataString(slug[..separatorIndex]);
+        string name = Uri.UnescapeDataString(slug[(separatorIndex + 1)..]);
+        return new RecipeKey(name, group);
+    }
+}

--- a/Data/Models/Recipe.cs
+++ b/Data/Models/Recipe.cs
@@ -4,10 +4,11 @@ namespace Reci.Data.Models;
 
 public class Recipe
 {
-    public Guid Id { get; set; }
-
     [Required(ErrorMessage = "Recipe name is required.")]
     public required string Name { get; set; }
+
+    [JsonIgnore]
+    public bool IsNew { get; set; } = true;
 
     public string? Description { get; set; }
 
@@ -34,8 +35,7 @@ public static class RecipeExtensions
         {
             return true;
         }
-        return recipe.Id == Guid.Empty
-            && string.IsNullOrEmpty(recipe.Name)
+        return string.IsNullOrEmpty(recipe.Name)
             && string.IsNullOrEmpty(recipe.Description)
             && recipe.Group is null
             && !recipe.Ingredients.Any(ingredient => !ingredient.IsEmpty())
@@ -51,8 +51,8 @@ public static class RecipeExtensions
         ArgumentNullException.ThrowIfNull(recipe);
         return new Recipe
         {
-            Id = recipe.Id,
             Name = recipe.Name,
+            IsNew = recipe.IsNew,
             Description = recipe.Description,
             Group = recipe.Group,
             Ingredients = recipe.Ingredients.Select(i => i with { }).ToList(),
@@ -74,8 +74,7 @@ public static class RecipeExtensions
         {
             return false;
         }
-        return first.Id == second.Id
-            && first.Name == second.Name
+        return first.Name == second.Name
             && first.Description == second.Description
             && first.Group == second.Group
             && first.Ingredients.SequenceEqual(second.Ingredients)

--- a/Data/Models/RecipeSummary.cs
+++ b/Data/Models/RecipeSummary.cs
@@ -2,8 +2,6 @@ namespace Reci.Data.Models;
 
 public record RecipeSummary
 {
-    public required Guid Id { get; init; }
-
     public required string Name { get; init; }
 
     public string? Description { get; init; }
@@ -12,13 +10,14 @@ public record RecipeSummary
 
     public List<string> Tags { get; init; } = [];
 
+    public string Slug => new RecipeKey(Name, Group).ToSlug();
+
     public static RecipeSummary FromRecipe(Recipe recipe)
     {
         ArgumentNullException.ThrowIfNull(recipe);
 
         return new RecipeSummary
         {
-            Id = recipe.Id,
             Name = recipe.Name,
             Description = recipe.Description,
             Group = recipe.Group,

--- a/Data/Repositories/FileSystemRecipeRepository.cs
+++ b/Data/Repositories/FileSystemRecipeRepository.cs
@@ -6,19 +6,19 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
     private readonly ILogger<FileSystemRecipeRepository> _logger = logger.ThrowIfNull();
     private readonly JsonSerializerOptions _jsonOptions = jsonOptions.ThrowIfNull();
 
-    private Dictionary<Guid, CachedRecipe>? _cache;
+    private Dictionary<RecipeKey, CachedRecipe>? _cache;
     private readonly SemaphoreSlim _cacheLock = new(1, 1);
 
-    public async Task<Recipe?> GetRecipeAsync(Guid id, CancellationToken cancellationToken = default)
+    public async Task<Recipe?> GetRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default)
     {
         try
         {
-            Dictionary<Guid, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
-            return cache.TryGetValue(id, out CachedRecipe? cached) ? cached.Recipe : null;
+            Dictionary<RecipeKey, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
+            return cache.TryGetValue(key, out CachedRecipe? cached) ? cached.Recipe : null;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving recipe with ID {RecipeId}", id);
+            _logger.LogError(ex, "Error retrieving recipe '{RecipeName}' in group '{Group}'", key.Name, key.Group);
             return null;
         }
     }
@@ -27,7 +27,7 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
     {
         try
         {
-            Dictionary<Guid, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
+            Dictionary<RecipeKey, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
             return cache.Values.Select(c => c.Recipe).ToList();
         }
         catch (Exception ex)
@@ -41,7 +41,7 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
     {
         try
         {
-            Dictionary<Guid, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
+            Dictionary<RecipeKey, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
             return cache.Values.Select(c => RecipeSummary.FromRecipe(c.Recipe)).ToList();
         }
         catch (Exception ex)
@@ -61,25 +61,25 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
             if (string.IsNullOrWhiteSpace(recipe.Name))
                 return Result.Failure("Recipe name is required");
 
-            Dictionary<Guid, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
+            Dictionary<RecipeKey, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
 
-            if (recipe.Id == Guid.Empty)
-                recipe.Id = Guid.NewGuid();
+            RecipeKey key = new(recipe.Name, recipe.Group);
 
-            if (cache.ContainsKey(recipe.Id))
-                return Result.Failure($"Recipe with ID {recipe.Id} already exists");
+            if (cache.ContainsKey(key))
+                return Result.Failure($"A recipe named '{recipe.Name}' already exists in group '{recipe.Group ?? "ungrouped"}'");
 
             string folderName = recipe.Group ?? string.Empty;
             if (!string.IsNullOrEmpty(folderName))
                 await EnsureFolderExistsAsync(folderName);
 
-            string fileName = FileNameHelper.ToFileName(recipe.Name, recipe.Id);
+            string fileName = FileNameHelper.ToFileName(recipe.Name);
             string filePath = string.IsNullOrEmpty(folderName) ? fileName : $"{folderName}/{fileName}";
 
             string json = JsonSerializer.Serialize(recipe, _jsonOptions);
             await _fileSystemAccess.WriteFileAsync(filePath, json);
 
-            cache[recipe.Id] = new CachedRecipe(recipe, filePath, folderName);
+            recipe.IsNew = false;
+            cache[key] = new CachedRecipe(recipe, filePath, folderName);
 
             _logger.LogInformation("Created recipe '{RecipeName}' at {FilePath}", recipe.Name, filePath);
             return Result.Success();
@@ -91,29 +91,31 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
         }
     }
 
-    public async Task<Result> UpdateRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default)
+    public async Task<Result> UpdateRecipeAsync(Recipe recipe, RecipeKey originalKey, CancellationToken cancellationToken = default)
     {
         try
         {
             if (recipe == null)
                 return Result.Failure("Recipe cannot be null");
 
-            if (recipe.Id == Guid.Empty)
-                return Result.Failure("Recipe ID is required");
-
             if (string.IsNullOrWhiteSpace(recipe.Name))
                 return Result.Failure("Recipe name is required");
 
-            Dictionary<Guid, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
+            Dictionary<RecipeKey, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
 
-            if (!cache.TryGetValue(recipe.Id, out CachedRecipe? existing))
-                return Result.Failure($"Recipe with ID {recipe.Id} not found");
+            if (!cache.TryGetValue(originalKey, out CachedRecipe? existing))
+                return Result.Failure($"Recipe '{originalKey.Name}' not found in group '{originalKey.Group ?? "ungrouped"}'");
+
+            RecipeKey newKey = new(recipe.Name, recipe.Group);
+
+            if (!originalKey.Equals(newKey) && cache.ContainsKey(newKey))
+                return Result.Failure($"A recipe named '{recipe.Name}' already exists in group '{recipe.Group ?? "ungrouped"}'");
 
             string newFolderName = recipe.Group ?? string.Empty;
             if (!string.IsNullOrEmpty(newFolderName))
                 await EnsureFolderExistsAsync(newFolderName);
 
-            string newFileName = FileNameHelper.ToFileName(recipe.Name, recipe.Id);
+            string newFileName = FileNameHelper.ToFileName(recipe.Name);
             string newFilePath = string.IsNullOrEmpty(newFolderName) ? newFileName : $"{newFolderName}/{newFileName}";
 
             string json = JsonSerializer.Serialize(recipe, _jsonOptions);
@@ -135,39 +137,40 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
                 await _fileSystemAccess.WriteFileAsync(newFilePath, json);
             }
 
-            cache[recipe.Id] = new CachedRecipe(recipe, newFilePath, newFolderName);
+            cache.Remove(originalKey);
+            cache[newKey] = new CachedRecipe(recipe, newFilePath, newFolderName);
 
             _logger.LogInformation("Updated recipe '{RecipeName}' at {FilePath}", recipe.Name, newFilePath);
             return Result.Success();
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating recipe with ID {RecipeId}", recipe?.Id);
+            _logger.LogError(ex, "Error updating recipe '{RecipeName}'", recipe?.Name);
             return Result.Failure($"Failed to update recipe: {ex.Message}");
         }
     }
 
-    public async Task<Result> DeleteRecipeAsync(Guid id, CancellationToken cancellationToken = default)
+    public async Task<Result> DeleteRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default)
     {
         try
         {
-            if (id == Guid.Empty)
-                return Result.Failure("Recipe ID is required");
+            if (string.IsNullOrWhiteSpace(key.Name))
+                return Result.Failure("Recipe name is required");
 
-            Dictionary<Guid, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
+            Dictionary<RecipeKey, CachedRecipe> cache = await GetOrLoadCacheAsync(cancellationToken);
 
-            if (!cache.TryGetValue(id, out CachedRecipe? existing))
-                return Result.Failure($"Recipe with ID {id} not found");
+            if (!cache.TryGetValue(key, out CachedRecipe? existing))
+                return Result.Failure($"Recipe '{key.Name}' not found in group '{key.Group ?? "ungrouped"}'");
 
             await _fileSystemAccess.DeleteFileAsync(existing.FilePath);
-            cache.Remove(id);
+            cache.Remove(key);
 
-            _logger.LogInformation("Deleted recipe with ID {RecipeId} from {FilePath}", id, existing.FilePath);
+            _logger.LogInformation("Deleted recipe '{RecipeName}' from {FilePath}", key.Name, existing.FilePath);
             return Result.Success();
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting recipe with ID {RecipeId}", id);
+            _logger.LogError(ex, "Error deleting recipe '{RecipeName}'", key.Name);
             return Result.Failure($"Failed to delete recipe: {ex.Message}");
         }
     }
@@ -186,7 +189,7 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
         await GetOrLoadCacheAsync(cancellationToken);
     }
 
-    private async Task<Dictionary<Guid, CachedRecipe>> GetOrLoadCacheAsync(CancellationToken cancellationToken = default)
+    private async Task<Dictionary<RecipeKey, CachedRecipe>> GetOrLoadCacheAsync(CancellationToken cancellationToken = default)
     {
         if (_cache is not null)
             return _cache;
@@ -207,9 +210,9 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
         }
     }
 
-    private async Task<Dictionary<Guid, CachedRecipe>> ScanAllRecipesAsync()
+    private async Task<Dictionary<RecipeKey, CachedRecipe>> ScanAllRecipesAsync()
     {
-        Dictionary<Guid, CachedRecipe> cache = new();
+        Dictionary<RecipeKey, CachedRecipe> cache = new();
 
         await ScanDirectoryAsync(cache, null, null);
 
@@ -226,7 +229,7 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
         return cache;
     }
 
-    private async Task ScanDirectoryAsync(Dictionary<Guid, CachedRecipe> cache, string? subfolder, string? folderName)
+    private async Task ScanDirectoryAsync(Dictionary<RecipeKey, CachedRecipe> cache, string? subfolder, string? folderName)
     {
         List<FileSystemEntry> entries = await _fileSystemAccess.ListEntriesAsync(subfolder);
 
@@ -244,15 +247,11 @@ public class FileSystemRecipeRepository(IFileSystemAccessService fileSystemAcces
                     continue;
                 }
 
-                if (recipe.Id == Guid.Empty)
-                {
-                    recipe.Id = Guid.NewGuid();
-                    _logger.LogInformation("Generated new ID for recipe '{RecipeName}' in {FilePath}", recipe.Name, filePath);
-                }
-
                 recipe.Group = folderName;
+                recipe.IsNew = false;
 
-                cache[recipe.Id] = new CachedRecipe(recipe, filePath, folderName);
+                RecipeKey key = new(recipe.Name, folderName);
+                cache[key] = new CachedRecipe(recipe, filePath, folderName);
             }
             catch (Exception ex)
             {

--- a/Data/Repositories/Interfaces/IRecipeRepository.cs
+++ b/Data/Repositories/Interfaces/IRecipeRepository.cs
@@ -2,7 +2,7 @@ namespace Reci.Data.Repositories.Interfaces;
 
 public interface IRecipeRepository
 {
-    Task<Recipe?> GetRecipeAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Recipe?> GetRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default);
 
     Task<List<Recipe>> GetRecipesAsync(CancellationToken cancellationToken = default);
 
@@ -10,9 +10,9 @@ public interface IRecipeRepository
 
     Task<Result> CreateRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default);
 
-    Task<Result> UpdateRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default);
+    Task<Result> UpdateRecipeAsync(Recipe recipe, RecipeKey originalKey, CancellationToken cancellationToken = default);
 
-    Task<Result> DeleteRecipeAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Result> DeleteRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default);
 
     Task RefreshCacheAsync(CancellationToken cancellationToken = default);
 }

--- a/Layout/Header.razor
+++ b/Layout/Header.razor
@@ -86,8 +86,8 @@
             {
                 case ExportKind.Recipe:
                 {
-                    Guid recipeId = Guid.Parse(context.Value!);
-                    RecipeExportResult? result = await RecipeExportService.ExportRecipeAsync(recipeId);
+                    RecipeKey key = RecipeKey.FromSlug(context.Value!);
+                    RecipeExportResult? result = await RecipeExportService.ExportRecipeAsync(key);
 
                     if (result is null)
                     {
@@ -151,9 +151,10 @@
         string relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
 
         if (relativePath.StartsWith("Recipe/", StringComparison.OrdinalIgnoreCase)
-            && Guid.TryParse(relativePath.AsSpan("Recipe/".Length), out Guid _))
+            && relativePath.Length > "Recipe/".Length)
         {
-            return new ExportContext(ExportKind.Recipe, relativePath["Recipe/".Length..]);
+            string slug = relativePath["Recipe/".Length..];
+            return new ExportContext(ExportKind.Recipe, slug);
         }
 
         if (relativePath.StartsWith("group/", StringComparison.OrdinalIgnoreCase)

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿
+
 @implements IAsyncDisposable
 @inject IDialogService DialogService
 @inject IRecipeService RecipeService
@@ -11,7 +11,7 @@
     <nav class="sitenav" aria-labelledby="main-menu">
         <FluentNavMenu Id="main-menu" Width="250" Collapsible="true" Title="Navigation menu" @bind-Expanded="expanded" CustomToggle="true">
              <FluentNavLink Href="/" Match="NavLinkMatch.All" Icon="@(new Icons.Regular.Size20.BookOpen())" IconColor="Color.Accent">Contents</FluentNavLink>
-            
+
              @foreach (IGrouping<string?, RecipeSummary> recipeGroup in recipeSummaries.GroupBy(r => r.Group).OrderBy(g => g.Key ?? string.Empty))
             {
                 @if (!string.IsNullOrEmpty(recipeGroup.Key))
@@ -27,14 +27,14 @@
                     @RenderRecipes(recipeGroup)
                 }
             }
-         
+
             <FluentDivider Style="margin: 10px 0;"></FluentDivider>
 
             <FluentNavLink Icon="@(new Icons.Regular.Size20.Add())"
                            OnClick="AddNewRecipe">
                 Add New Recipe
             </FluentNavLink>
-         
+
          </FluentNavMenu>
     </nav>
 </div>
@@ -87,7 +87,7 @@
     {
         @foreach (RecipeSummary recipe in recipeGroup)
         {
-            <FluentNavLink Href="@($"/recipe/{recipe.Id}")"
+            <FluentNavLink Href="@($"/recipe/{recipe.Slug}")"
                            Icon="@(new Icons.Regular.Size20.Food())">
                 @recipe.Name
             </FluentNavLink>

--- a/Pages/Contents.razor
+++ b/Pages/Contents.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+@page "/"
 @page "/group/{GroupName}"
 @implements IAsyncDisposable
 @inject IRecipeService RecipeService
@@ -42,15 +42,16 @@ else
 
             @foreach (RecipeSummary recipe in group)
             {
-                <FluentGridItem xs="12" sm="6" md="4" lg="3" @key="recipe.Id">
-                    <FluentCard class="recipe-card" MinimalStyle="true" @onclick="() => NavigateToRecipe(recipe.Id)">
+                string anchorId = $"description-{recipe.Slug.GetHashCode():x}";
+                <FluentGridItem xs="12" sm="6" md="4" lg="3" @key="recipe.Slug">
+                    <FluentCard class="recipe-card" MinimalStyle="true" @onclick="() => NavigateToRecipe(recipe)">
                         <FluentStack Orientation="Orientation.Vertical">
                             <FluentLabel Typo="Typography.H5">@recipe.Name</FluentLabel>
 
                             @if (!string.IsNullOrEmpty(recipe.Description))
                             {
-                                <FluentLabel Id="@($"description-{recipe.Id}")" Color="Color.Custom" CustomColor="var(--neutral-foreground-hint)" Class="recipe-description">@recipe.Description</FluentLabel>
-                                <FluentTooltip Anchor="@($"description-{recipe.Id}")" Position="TooltipPosition.Bottom" Delay="500" MaxWidth="300px">
+                                <FluentLabel Id="@anchorId" Color="Color.Custom" CustomColor="var(--neutral-foreground-hint)" Class="recipe-description">@recipe.Description</FluentLabel>
+                                <FluentTooltip Anchor="@anchorId" Position="TooltipPosition.Bottom" Delay="500" MaxWidth="300px">
                                     @recipe.Description
                                 </FluentTooltip>
                             }
@@ -152,8 +153,8 @@ else
         }
     }
 
-    private void NavigateToRecipe(Guid recipeId)
+    private void NavigateToRecipe(RecipeSummary recipe)
     {
-        NavigationManager.NavigateTo($"/recipe/{recipeId}");
+        NavigationManager.NavigateTo($"/recipe/{recipe.Slug}");
     }
 }

--- a/Pages/RecipePage.razor
+++ b/Pages/RecipePage.razor
@@ -1,4 +1,4 @@
-﻿@page "/Recipe/{RecipeSlug?}"
+@page "/Recipe/{*RecipeSlug}"
 @implements IAsyncDisposable
 @inject IRecipeService RecipeService
 @inject IRecipeStateNotifier RecipeStateNotifier
@@ -74,7 +74,7 @@ else
                 <FluentLabel>@Recipe.Description</FluentLabel>
             </FluentGridItem>
         }
-        
+
         <FluentGridItem xs="12">
             <FluentDivider Role="DividerRole.Separator" />
         </FluentGridItem>
@@ -83,14 +83,14 @@ else
         {
             <FluentGridItem xs="12" md="6">
                 <IngredientsDisplay Ingredients="@Recipe.Ingredients" />
-            </FluentGridItem>            
+            </FluentGridItem>
         }
 
         @if (Recipe.Instructions.Any())
         {
             <FluentGridItem xs="12" md="6">
                 <InstructionsDisplay Instructions="@Recipe.Instructions" />
-            </FluentGridItem>  
+            </FluentGridItem>
         }
 
         @if (!Recipe.NutritionInfo.IsEmpty())
@@ -141,8 +141,15 @@ else
 
         try
         {
-            bool success = Guid.TryParse(RecipeSlug, out Guid recipeId);
-            Recipe = success ? await RecipeService.GetRecipeAsync(recipeId, _cts.Token) : null;
+            if (!string.IsNullOrEmpty(RecipeSlug))
+            {
+                RecipeKey key = RecipeKey.FromSlug(RecipeSlug);
+                Recipe = await RecipeService.GetRecipeAsync(key, _cts.Token);
+            }
+            else
+            {
+                Recipe = null;
+            }
         }
         finally
         {
@@ -201,5 +208,15 @@ else
         });
 
         DialogResult result = await _dialog.Result;
+
+        if (!result.Cancelled && Recipe is not null)
+        {
+            RecipeKey newKey = new(Recipe.Name, Recipe.Group);
+            string newSlug = newKey.ToSlug();
+            if (!string.Equals(RecipeSlug, newSlug, StringComparison.Ordinal))
+            {
+                NavigationManager.NavigateTo($"/recipe/{newSlug}");
+            }
+        }
     }
 }

--- a/Recipes/Breakfast/Banana Oat Pancakes.reci
+++ b/Recipes/Breakfast/Banana Oat Pancakes.reci
@@ -1,5 +1,4 @@
 {
-  "id": "48cdf080-f187-4a53-a916-2b27315062d7",
   "name": "Banana Oat Pancakes",
   "description": "Fluffy, naturally sweet pancakes made with oats and bananas. Freezer-friendly for quick weekday breakfasts the whole family will love.",
   "group": "Breakfast",

--- a/Recipes/Breakfast/Overnight Oats.reci
+++ b/Recipes/Breakfast/Overnight Oats.reci
@@ -1,5 +1,4 @@
 {
-  "id": "0dbd4f50-67d5-444a-8d49-f5435c12788f",
   "name": "Overnight Oats",
   "description": "Creamy no-cook oats with chia seeds, honey, and vanilla that you prep the night before. Grab-and-go breakfast ready in minutes.",
   "group": "Breakfast",

--- a/Recipes/Breakfast/Shakshuka.reci
+++ b/Recipes/Breakfast/Shakshuka.reci
@@ -1,5 +1,4 @@
 {
-  "id": "134296aa-de40-4900-9d9f-1f7c9639b052",
   "name": "Shakshuka",
   "description": "Eggs poached in a spiced, chunky tomato-pepper sauce with crumbled feta. A one-pan North African breakfast that works at any time of day.",
   "group": "Breakfast",

--- a/Recipes/Meal Prep - Beef/Korean Beef Bowl Meal Prep.reci
+++ b/Recipes/Meal Prep - Beef/Korean Beef Bowl Meal Prep.reci
@@ -1,5 +1,4 @@
 {
-  "id": "1b3254fb-b250-465e-b755-0b6a268b04cf",
   "name": "Korean Beef Bowl Meal Prep",
   "description": "Korean BBQ in meal prep form that provides a full meal without getting you to overeat, or lead you to a food coma mid-afternoon.",
   "group": "Meal Prep - Beef",

--- a/Recipes/Meal Prep - Chicken/Chicken Teriyaki Bowl.reci
+++ b/Recipes/Meal Prep - Chicken/Chicken Teriyaki Bowl.reci
@@ -1,5 +1,4 @@
 {
-  "id": "89d4a839-02e0-4966-83c1-d6a43b14e2a3",
   "name": "Chicken Teriyaki Bowl",
   "description": "Sweet and savory teriyaki chicken over fluffy rice with steamed broccoli and edamame. A balanced meal prep staple that reheats beautifully.",
   "group": "Meal Prep - Chicken",

--- a/Recipes/Meal Prep - Chicken/Chicken Tikka Masala.reci
+++ b/Recipes/Meal Prep - Chicken/Chicken Tikka Masala.reci
@@ -1,5 +1,4 @@
 {
-  "id": "aa6aed4d-2496-4ec8-b936-915b9ceff204",
   "name": "Chicken Tikka Masala",
   "description": "Tender marinated chicken pieces swimming in a rich, creamy spiced tomato sauce. Better than takeaway and perfect for batch cooking.",
   "group": "Meal Prep - Chicken",

--- a/Recipes/Meal Prep - Chicken/Greek Chicken Bowl.reci
+++ b/Recipes/Meal Prep - Chicken/Greek Chicken Bowl.reci
@@ -1,5 +1,4 @@
 {
-  "id": "6376364f-9e9b-40a0-b956-973fb414ec8a",
   "name": "Greek Chicken Bowl",
   "description": "Juicy lemon-herb grilled chicken over rice with cucumber, tomatoes, red onion, and a cool creamy tzatziki. A fresh, satisfying meal prep bowl.",
   "group": "Meal Prep - Chicken",

--- a/Recipes/Meal Prep/Beef Enchiladas.reci
+++ b/Recipes/Meal Prep/Beef Enchiladas.reci
@@ -1,5 +1,4 @@
 {
-  "id": "e1bd8fd5-338e-48bb-bd0b-6375d4815e40",
   "name": "Beef Enchiladas",
   "description": "Slow-simmered seasoned beef rolled in tortillas, smothered in enchilada sauce and melted cheese. Freezer-friendly for batch cooking.",
   "group": "Meal Prep",

--- a/Recipes/Meal Prep/Mediterranean Quinoa Salad.reci
+++ b/Recipes/Meal Prep/Mediterranean Quinoa Salad.reci
@@ -1,5 +1,4 @@
 {
-  "id": "2685ea18-92d8-4d5b-a16c-0af42d40787e",
   "name": "Mediterranean Quinoa Salad",
   "description": "A bright, refreshing quinoa salad loaded with crunchy vegetables, feta, and a zesty lemon-herb dressing. Perfect cold or at room temperature.",
   "group": "Meal Prep",

--- a/Recipes/Meal Prep/Turkey Meatball Soup.reci
+++ b/Recipes/Meal Prep/Turkey Meatball Soup.reci
@@ -1,5 +1,4 @@
 {
-  "id": "d9055a20-ebe4-44a4-9c1a-7204f61a6efb",
   "name": "Turkey Meatball Soup",
   "description": "Hearty, nourishing soup with tender turkey meatballs, vegetables, and orzo pasta in a savory broth. Comfort in a bowl that freezes perfectly.",
   "group": "Meal Prep",

--- a/Recipes/Quick Weeknight/Black Bean Tacos.reci
+++ b/Recipes/Quick Weeknight/Black Bean Tacos.reci
@@ -1,5 +1,4 @@
 {
-  "id": "8b528edb-6d14-4a81-802f-618d477f37a5",
   "name": "Black Bean Tacos",
   "description": "Smoky, seasoned black beans piled into warm tortillas with fresh toppings. A quick vegetarian dinner that rivals any taco truck.",
   "group": "Quick Weeknight",

--- a/Recipes/Quick Weeknight/Caprese Stuffed Chicken.reci
+++ b/Recipes/Quick Weeknight/Caprese Stuffed Chicken.reci
@@ -1,5 +1,4 @@
 {
-  "id": "e320505b-b744-4217-b11a-c79cb299b32e",
   "name": "Caprese Stuffed Chicken",
   "description": "Juicy chicken breasts stuffed with fresh mozzarella, sun-dried tomatoes, and basil, wrapped in prosciutto. An impressive weeknight dinner in under 30 minutes.",
   "group": "Quick Weeknight",

--- a/Recipes/Quick Weeknight/Honey Garlic Shrimp.reci
+++ b/Recipes/Quick Weeknight/Honey Garlic Shrimp.reci
@@ -1,5 +1,4 @@
 {
-  "id": "4104b900-390c-41d5-b82e-876a82bd2a2f",
   "name": "Honey Garlic Shrimp",
   "description": "Plump shrimp glazed in a sticky, sweet-savory honey garlic sauce. Ready in under 15 minutes for the fastest weeknight dinner.",
   "group": "Quick Weeknight",

--- a/Recipes/Quick Weeknight/Lemon Herb Salmon.reci
+++ b/Recipes/Quick Weeknight/Lemon Herb Salmon.reci
@@ -1,5 +1,4 @@
 {
-  "id": "87aa2102-6129-4c57-9706-03cab2895540",
   "name": "Lemon Herb Salmon",
   "description": "Flaky, buttery salmon fillets baked with lemon, garlic, and fresh herbs. An elegant weeknight dinner that comes together in 20 minutes.",
   "group": "Quick Weeknight",

--- a/Recipes/Quick Weeknight/Thai Peanut Noodles.reci
+++ b/Recipes/Quick Weeknight/Thai Peanut Noodles.reci
@@ -1,5 +1,4 @@
 {
-  "id": "391875be-2fc9-46e5-a5e6-c007d741c435",
   "name": "Thai Peanut Noodles",
   "description": "Chewy noodles tossed in a creamy, spicy peanut sauce with crunchy vegetables and fresh herbs. Equally delicious hot or cold.",
   "group": "Quick Weeknight",

--- a/Recipes/Snacks & Desserts/Chocolate Protein Balls.reci
+++ b/Recipes/Snacks & Desserts/Chocolate Protein Balls.reci
@@ -1,5 +1,4 @@
 {
-  "id": "d675762a-45e2-415b-85d5-34d9920c2a95",
   "name": "Chocolate Protein Balls",
   "description": "Rich, fudgy no-bake energy balls packed with oats, peanut butter, and chocolate chips. The perfect pre-workout or afternoon snack.",
   "group": "Snacks & Desserts",

--- a/Recipes/Snacks & Desserts/Protein Waffles.reci
+++ b/Recipes/Snacks & Desserts/Protein Waffles.reci
@@ -1,5 +1,4 @@
 {
-  "id": "93145c3e-c94a-471e-89ef-c9885980e228",
   "name": "Protein Waffles",
   "description": "Crispy, golden waffles packed with protein from eggs and protein powder, naturally sweetened with banana. A quick, healthy breakfast or snack that doubles as pancake batter.",
   "group": "Snacks & Desserts",

--- a/Recipes/Wraps/Cheeseburger Wraps.reci
+++ b/Recipes/Wraps/Cheeseburger Wraps.reci
@@ -1,5 +1,4 @@
 {
-  "id": "5da309c4-f5f0-406a-bcc4-0ae1d484e1f3",
   "name": "Cheeseburger Wraps",
   "description": "High protein cheeseburger wraps that taste amazing and reheat perfectly. Easy, affordable meal prep for muscle gain, weight loss, or healthy lunches.",
   "group": "Wraps",

--- a/Recipes/Wraps/Chorizo & Egg Breakfast Wrap.reci
+++ b/Recipes/Wraps/Chorizo & Egg Breakfast Wrap.reci
@@ -1,5 +1,4 @@
 {
-  "id": "6861353c-c2cf-45ff-acfb-40e694ee0aa5",
   "name": "Chorizo & Egg Breakfast Wrap",
   "description": "Smoky chorizo, soft scrambled eggs, cheese, and spinach wrapped in tortillas. Prep five wraps in twenty minutes for convenient, flavour-packed breakfast that stores beautifully.",
   "group": "Wraps",

--- a/Services/Interfaces/IRecipeExportService.cs
+++ b/Services/Interfaces/IRecipeExportService.cs
@@ -8,5 +8,5 @@ public interface IRecipeExportService
 
     Task<byte[]?> ExportGroupAsZipAsync(string groupName, CancellationToken cancellationToken = default);
 
-    Task<RecipeExportResult?> ExportRecipeAsync(Guid recipeId, CancellationToken cancellationToken = default);
+    Task<RecipeExportResult?> ExportRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default);
 }

--- a/Services/Interfaces/IRecipeService.cs
+++ b/Services/Interfaces/IRecipeService.cs
@@ -4,13 +4,13 @@ public interface IRecipeService
 {
     Task<List<RecipeSummary>> GetRecipeSummariesAsync(CancellationToken cancellationToken = default);
 
-    Task<Recipe?> GetRecipeAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Recipe?> GetRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default);
 
-    Task<Result> SaveRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default);
+    Task<Result> SaveRecipeAsync(Recipe recipe, RecipeKey? originalKey = null, CancellationToken cancellationToken = default);
 
-    Task<Result> DeleteRecipeAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Result> DeleteRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default);
 
-    Task<bool> IsRecipeModifiedAsync(Recipe recipe, CancellationToken cancellationToken = default);
+    Task<bool> IsRecipeModifiedAsync(Recipe recipe, RecipeKey? originalKey = null, CancellationToken cancellationToken = default);
 
     bool IsRecipeEmpty(Recipe recipe);
 }

--- a/Services/RecipeExportService.cs
+++ b/Services/RecipeExportService.cs
@@ -57,30 +57,30 @@ public class RecipeExportService(IRecipeRepository recipeRepository, ILogger<Rec
         }
     }
 
-    public async Task<RecipeExportResult?> ExportRecipeAsync(Guid recipeId, CancellationToken cancellationToken = default)
+    public async Task<RecipeExportResult?> ExportRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default)
     {
         try
         {
-            _logger.LogDebug("Starting single recipe export for ID {RecipeId}", recipeId);
+            _logger.LogDebug("Starting single recipe export for '{RecipeName}'", key.Name);
 
-            Recipe? recipe = await _recipeRepository.GetRecipeAsync(recipeId, cancellationToken);
+            Recipe? recipe = await _recipeRepository.GetRecipeAsync(key, cancellationToken);
 
             if (recipe is null)
             {
-                _logger.LogWarning("Recipe with ID {RecipeId} not found for export", recipeId);
+                _logger.LogWarning("Recipe '{RecipeName}' not found for export", key.Name);
                 return null;
             }
 
             string json = JsonSerializer.Serialize(recipe, _jsonOptions);
             byte[] content = Encoding.UTF8.GetBytes(json);
-            string fileName = FileNameHelper.ToFileName(recipe.Name, recipe.Id);
+            string fileName = FileNameHelper.ToFileName(recipe.Name);
 
             _logger.LogInformation("Exported recipe '{RecipeName}'", recipe.Name);
             return new RecipeExportResult(content, fileName);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error exporting recipe with ID {RecipeId}", recipeId);
+            _logger.LogError(ex, "Error exporting recipe '{RecipeName}'", key.Name);
             return null;
         }
     }
@@ -92,7 +92,7 @@ public class RecipeExportService(IRecipeRepository recipeRepository, ILogger<Rec
         {
             foreach (Recipe recipe in recipes)
             {
-                string fileName = FileNameHelper.ToFileName(recipe.Name, recipe.Id);
+                string fileName = FileNameHelper.ToFileName(recipe.Name);
                 string entryPath = string.IsNullOrEmpty(recipe.Group) ? fileName : $"{recipe.Group}/{fileName}";
 
                 ZipArchiveEntry entry = archive.CreateEntry(entryPath);

--- a/Services/RecipeService.cs
+++ b/Services/RecipeService.cs
@@ -15,38 +15,39 @@ public class RecipeService(IRecipeRepository recipeRepository, IRecipeStateNotif
         return summaries;
     }
 
-    public async Task<Recipe?> GetRecipeAsync(Guid id, CancellationToken cancellationToken = default)
+    public async Task<Recipe?> GetRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving recipe with ID {RecipeId}", id);
-        Recipe? recipe = await _recipeRepository.GetRecipeAsync(id, cancellationToken);
+        _logger.LogDebug("Retrieving recipe '{RecipeName}' in group '{Group}'", key.Name, key.Group);
+        Recipe? recipe = await _recipeRepository.GetRecipeAsync(key, cancellationToken);
 
         if (recipe is null)
         {
-            _logger.LogWarning("Recipe with ID {RecipeId} not found", id);
+            _logger.LogWarning("Recipe '{RecipeName}' not found in group '{Group}'", key.Name, key.Group);
         }
 
         return recipe;
     }
 
-    public async Task<Result> SaveRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default)
+    public async Task<Result> SaveRecipeAsync(Recipe recipe, RecipeKey? originalKey = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(recipe);
 
         Result result;
-        if (recipe.Id == Guid.Empty)
+        if (recipe.IsNew)
         {
             _logger.LogDebug("Creating new recipe '{RecipeName}'", recipe.Name);
             result = await _recipeRepository.CreateRecipeAsync(recipe, cancellationToken);
         }
         else
         {
-            _logger.LogDebug("Updating recipe with ID {RecipeId}", recipe.Id);
-            result = await _recipeRepository.UpdateRecipeAsync(recipe, cancellationToken);
+            RecipeKey key = originalKey ?? new RecipeKey(recipe.Name, recipe.Group);
+            _logger.LogDebug("Updating recipe '{RecipeName}'", recipe.Name);
+            result = await _recipeRepository.UpdateRecipeAsync(recipe, key, cancellationToken);
         }
 
         if (result.IsSuccess)
         {
-            _logger.LogInformation("Successfully saved recipe '{RecipeName}' with ID {RecipeId}", recipe.Name, recipe.Id);
+            _logger.LogInformation("Successfully saved recipe '{RecipeName}'", recipe.Name);
             await _recipeStateNotifier.NotifyRecipesChangedAsync();
         }
         else
@@ -57,34 +58,35 @@ public class RecipeService(IRecipeRepository recipeRepository, IRecipeStateNotif
         return result;
     }
 
-    public async Task<Result> DeleteRecipeAsync(Guid id, CancellationToken cancellationToken = default)
+    public async Task<Result> DeleteRecipeAsync(RecipeKey key, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Deleting recipe with ID {RecipeId}", id);
-        Result result = await _recipeRepository.DeleteRecipeAsync(id, cancellationToken);
+        _logger.LogDebug("Deleting recipe '{RecipeName}' in group '{Group}'", key.Name, key.Group);
+        Result result = await _recipeRepository.DeleteRecipeAsync(key, cancellationToken);
 
         if (result.IsSuccess)
         {
-            _logger.LogInformation("Successfully deleted recipe with ID {RecipeId}", id);
+            _logger.LogInformation("Successfully deleted recipe '{RecipeName}'", key.Name);
             await _recipeStateNotifier.NotifyRecipesChangedAsync();
         }
         else
         {
-            _logger.LogWarning("Failed to delete recipe with ID {RecipeId}: {Error}", id, result.ErrorMessage);
+            _logger.LogWarning("Failed to delete recipe '{RecipeName}': {Error}", key.Name, result.ErrorMessage);
         }
 
         return result;
     }
 
-    public async Task<bool> IsRecipeModifiedAsync(Recipe recipe, CancellationToken cancellationToken = default)
+    public async Task<bool> IsRecipeModifiedAsync(Recipe recipe, RecipeKey? originalKey = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(recipe);
 
-        if (recipe.Id == Guid.Empty)
+        if (recipe.IsNew)
         {
             return true;
         }
 
-        Recipe? originalRecipe = await _recipeRepository.GetRecipeAsync(recipe.Id, cancellationToken);
+        RecipeKey key = originalKey ?? new RecipeKey(recipe.Name, recipe.Group);
+        Recipe? originalRecipe = await _recipeRepository.GetRecipeAsync(key, cancellationToken);
 
         if (originalRecipe == null)
         {

--- a/Services/SearchService.cs
+++ b/Services/SearchService.cs
@@ -13,7 +13,7 @@ public class SearchService(IRecipeService recipeService) : ISearchService
 
         List<RecipeSummary> summaries = await recipeService.GetRecipeSummariesAsync(cancellationToken);
         List<SearchResult> results = new(MaxResults);
-        HashSet<Guid> matchedRecipeIds = [];
+        HashSet<string> matchedSlugs = [];
 
         foreach (RecipeSummary summary in summaries)
         {
@@ -24,7 +24,7 @@ public class SearchService(IRecipeService recipeService) : ISearchService
 
             if (summary.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
             {
-                matchedRecipeIds.Add(summary.Id);
+                matchedSlugs.Add(summary.Slug);
                 results.Add(CreateRecipeResult(summary, MatchMethod.Name));
             }
         }
@@ -62,14 +62,14 @@ public class SearchService(IRecipeService recipeService) : ISearchService
                     break;
                 }
 
-                if (matchedRecipeIds.Contains(summary.Id))
+                if (matchedSlugs.Contains(summary.Slug))
                 {
                     continue;
                 }
 
                 if (summary.Tags.Any(tag => tag.Contains(query, StringComparison.OrdinalIgnoreCase)))
                 {
-                    matchedRecipeIds.Add(summary.Id);
+                    matchedSlugs.Add(summary.Slug);
                     results.Add(CreateRecipeResult(summary, MatchMethod.Tag));
                 }
             }
@@ -84,7 +84,7 @@ public class SearchService(IRecipeService recipeService) : ISearchService
                     break;
                 }
 
-                if (matchedRecipeIds.Contains(summary.Id))
+                if (matchedSlugs.Contains(summary.Slug))
                 {
                     continue;
                 }
@@ -92,7 +92,7 @@ public class SearchService(IRecipeService recipeService) : ISearchService
                 if (summary.Description is not null
                     && summary.Description.Contains(query, StringComparison.OrdinalIgnoreCase))
                 {
-                    matchedRecipeIds.Add(summary.Id);
+                    matchedSlugs.Add(summary.Slug);
                     results.Add(CreateRecipeResult(summary, MatchMethod.Description));
                 }
             }
@@ -108,7 +108,7 @@ public class SearchService(IRecipeService recipeService) : ISearchService
             Name = summary.Name,
             Kind = SearchResultKind.Recipe,
             MatchMethod = matchMethod,
-            NavigationUrl = $"/Recipe/{summary.Id}"
+            NavigationUrl = $"/Recipe/{summary.Slug}"
         };
     }
 }

--- a/Tests/Utilities/ReciPage.cs
+++ b/Tests/Utilities/ReciPage.cs
@@ -30,17 +30,20 @@ public abstract class ReciPage : PageTest
         await WaitForAppReadyAsync();
     }
 
-    public async Task GotoRecipeAsync(Guid recipeId)
+    public async Task GotoRecipeAsync(string recipeName, string? group = null)
     {
         await EnsureStateInitializedAsync();
-        await Page.GotoAsync($"{_app.BaseUrl}/recipe/{recipeId}");
+        string slug = group is not null
+            ? $"{Uri.EscapeDataString(group)}/{Uri.EscapeDataString(recipeName)}"
+            : Uri.EscapeDataString(recipeName);
+        await Page.GotoAsync($"{_app.BaseUrl}/recipe/{slug}");
         await WaitForAppReadyAsync();
     }
 
-    public async Task GotoGroupAsync(Guid groupId)
+    public async Task GotoGroupAsync(string groupName)
     {
         await EnsureStateInitializedAsync();
-        await Page.GotoAsync($"{_app.BaseUrl}/group/{groupId}");
+        await Page.GotoAsync($"{_app.BaseUrl}/group/{Uri.EscapeDataString(groupName)}");
         await WaitForAppReadyAsync();
     }
 

--- a/Tests/Views/ContentsPageTests.cs
+++ b/Tests/Views/ContentsPageTests.cs
@@ -23,8 +23,7 @@ public class ContentsPageTests(AppFixture app) : ReciPage(app)
     [ReciPageState]
     public async Task GroupFilter_ShowsOnlyGroupRecipes()
     {
-        Guid breakfastGroupId = new("10000000-0000-0000-0000-000000000001");
-        await GotoGroupAsync(breakfastGroupId);
+        await GotoGroupAsync("Breakfast");
         await Expect(Page).ToHaveTitleAsync("Breakfast");
 
         await ScreenshotAssert.MatchesAsync(Page, "ContentsPage-GroupFilter");
@@ -47,10 +46,9 @@ public class ContentsPageTests(AppFixture app) : ReciPage(app)
     [ReciPageState]
     public async Task PageTitle_ViewingGroup()
     {
-        const string GroupId = "10000000-0000-0000-0000-000000000002";
         const string GroupPageTitle = "Dinner";
 
-        await GotoGroupAsync(new Guid(GroupId));
+        await GotoGroupAsync("Dinner");
 
         await Expect(Page).ToHaveTitleAsync(GroupPageTitle);
     }

--- a/Tests/Views/RecipePageTests.cs
+++ b/Tests/Views/RecipePageTests.cs
@@ -6,8 +6,7 @@ public class RecipePageTests(AppFixture app) : ReciPage(app)
     [ReciPageState]
     public async Task SimpleRecipe_ShowsAllFields()
     {
-        Guid pancakesId = new("20000000-0000-0000-0000-000000000001");
-        await GotoRecipeAsync(pancakesId);
+        await GotoRecipeAsync("Classic Pancakes", "Breakfast");
         await Expect(Page).ToHaveTitleAsync("Classic Pancakes");
 
         await ScreenshotAssert.MatchesAsync(Page, "RecipePage-SimpleRecipe", fullPage: true);
@@ -17,8 +16,7 @@ public class RecipePageTests(AppFixture app) : ReciPage(app)
     [ReciPageState]
     public async Task RecipeWithGroupedIngredients_ShowsGroupedLayout()
     {
-        Guid spaghettiId = new("20000000-0000-0000-0000-000000000002");
-        await GotoRecipeAsync(spaghettiId);
+        await GotoRecipeAsync("Spaghetti Bolognese", "Dinner");
         await Expect(Page).ToHaveTitleAsync("Spaghetti Bolognese");
 
         await ScreenshotAssert.MatchesAsync(Page, "RecipePage-GroupedIngredients", fullPage: true);
@@ -28,8 +26,7 @@ public class RecipePageTests(AppFixture app) : ReciPage(app)
     [ReciPageState]
     public async Task RecipeNotFound_ShowsNotFoundMessage()
     {
-        Guid nonExistentId = new("99999999-9999-9999-9999-999999999999");
-        await GotoRecipeAsync(nonExistentId);
+        await GotoRecipeAsync("NonExistentRecipe");
         await Expect(Page).ToHaveTitleAsync("Recipe");
 
         await ScreenshotAssert.MatchesAsync(Page, "RecipePage-NotFound");


### PR DESCRIPTION
## Summary
- Removes the `Guid Id` property from `Recipe`, using `Name + Group` as the composite identifier via a new `RecipeKey` value type
- Simplifies filenames from `{Name}_{GuidPrefix}.reci` to `{Name}.reci` and URLs from `/recipe/{guid}` to `/recipe/{group}/{name}`
- Adds `IsNew` flag on Recipe to replace `Id == Guid.Empty` checks, and `originalKey` parameter on update to support rename with file move

## Test plan
- [ ] `dotnet build -c Release` passes
- [ ] `dotnet format Reci.slnx --verify-no-changes` passes
- [ ] Create a recipe (no group) — verify URL is `/recipe/{name}`
- [ ] Create a recipe with group — verify URL is `/recipe/{group}/{name}`
- [ ] Edit and rename a recipe — verify URL updates and file on disk renamed
- [ ] Export single recipe, group, and all — verify downloads work
- [ ] Nav menu and search links navigate correctly
- [ ] Delete a recipe from editor
- [ ] Verify duplicate name in same group is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)